### PR TITLE
Fix typo in unit backend adapter

### DIFF
--- a/connector_woocommerce/unit/backend_adapter.py
+++ b/connector_woocommerce/unit/backend_adapter.py
@@ -76,10 +76,10 @@ def output_recorder(filename):
 
 class WooLocation(object):
 
-    def __init__(self, location, consumer_key, consumre_secret):
+    def __init__(self, location, consumer_key, consumer_secret):
         self._location = location
         self.consumer_key = consumer_key
-        self.consumer_secret = consumre_secret
+        self.consumer_secret = consumer_secret
 
     @property
     def location(self):


### PR DESCRIPTION
I saw a little typo in backend_adapter.py file in unit directory and fixed it.
